### PR TITLE
Fix baseline version with simple sinh

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -159,8 +159,8 @@ static void BaselineSimpleSinh(benchmark::State &state) {
   std::vector<float> results(input.bulkSize);
   benchmark::DoNotOptimize(results);
   for (auto _ : state) {
-    EvalLoop(input.bulkSize, input.eventMask, input.pts, input.etas, input.phis,
-             input.masses, input.sizes, results);
+    EvalLoopSimpleSinh(input.bulkSize, input.eventMask, input.pts, input.etas,
+                       input.phis, input.masses, input.sizes, results);
     // to force writing to memory of results
     benchmark::ClobberMemory();
   }


### PR DESCRIPTION
Actually call the correct evaluation function.

---

On my system (without any of the measures like disabling HT or frequency locking, so *take with a grain of salt*):
```
2023-04-21T17:00:22+02:00
Running ./bench
Run on (8 X 4200 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 0.51, 0.64, 0.65
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
Baseline                      51726 ns        51681 ns        11217
BaselineSimpleSinh            25122 ns        25086 ns        27684
Bulk                          50795 ns        50713 ns        13569
BulkIgnoreMask                47429 ns        47295 ns        14766
BulkIgnoreMaskSimpleSinh      24876 ns        24701 ns        26597
```