### PR TITLE
Add another variant with sinhf taken from Cephes

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -105,6 +105,24 @@ static float SinhPowerSeries(float x) {
   return x + t3 + t5 + t7 + t9;
 }
 
+// taken from Cephes' sinhf.c, using a polynomial approximation for |x| < 1
+static float SinhCephes(float x) {
+  float z = std::abs(x);
+  if (z > 1) {
+    z = std::exp(z);
+    z = 0.5f * z - 0.5f / z;
+    if (x < 0) {
+      z = -z;
+    }
+  } else {
+    z = x * x;
+    z = ((2.03721912945E-4f * z + 8.33028376239E-3f) * z + 1.66667160211E-1f) *
+            z * x +
+        x;
+  }
+  return z;
+}
+
 // original
 template <typename T>
 T InvariantMassBaseline(const T *pt, const T *eta, const T *phi, const T *mass,
@@ -213,6 +231,61 @@ static void BaselineSimpleSinh(benchmark::State &state) {
   SanityCheck(results);
 }
 BENCHMARK(BaselineSimpleSinh);
+
+template <typename T>
+T InvMassBaselineSinhCephes(const T *pt, const T *eta, const T *phi,
+                            const T *mass, std::size_t size) {
+  T x_sum = 0.;
+  T y_sum = 0.;
+  T z_sum = 0.;
+  T e_sum = 0.;
+
+  for (std::size_t i = 0u; i < size; ++i) {
+    // Convert to (e, x, y, z) coordinate system and update sums
+    const auto x = pt[i] * std::cos(phi[i]);
+    x_sum += x;
+    const auto y = pt[i] * std::sin(phi[i]);
+    y_sum += y;
+    const auto z = pt[i] * SinhCephes(eta[i]);
+    z_sum += z;
+    const auto e = std::sqrt(x * x + y * y + z * z + mass[i] * mass[i]);
+    e_sum += e;
+  }
+
+  // Return invariant mass with (+, -, -, -) metric
+  return std::sqrt(e_sum * e_sum - x_sum * x_sum - y_sum * y_sum -
+                   z_sum * z_sum);
+}
+
+static void EvalLoopSinhCephes(std::size_t bulkSize,
+                               const std::vector<bool> &eventMask, float *pts,
+                               float *etas, float *phis, float *masses,
+                               std::size_t *sizes,
+                               std::vector<float> &results) {
+  std::size_t elementIdx = 0u;
+  for (std::size_t i = 0ul; i < bulkSize; ++i) {
+    if (eventMask[i]) { // we don't have a value for this entry yet
+      results[i] = InvMassBaselineSinhCephes(
+          pts + elementIdx, etas + elementIdx, phis + elementIdx,
+          masses + elementIdx, sizes[i]);
+    }
+    elementIdx += sizes[i];
+  }
+}
+
+static void BaselineSinhCephes(benchmark::State &state) {
+  std::vector<float> results(input.bulkSize);
+  benchmark::DoNotOptimize(results);
+  for (auto _ : state) {
+    EvalLoopSinhCephes(input.bulkSize, input.eventMask, input.pts, input.etas,
+                       input.phis, input.masses, input.sizes, results);
+    // to force writing to memory of results
+    benchmark::ClobberMemory();
+  }
+
+  SanityCheck(results);
+}
+BENCHMARK(BaselineSinhCephes);
 
 template <typename T>
 T InvMassBaselinePowerSeries(const T *pt, const T *eta, const T *phi,
@@ -475,6 +548,85 @@ static void BulkIgnoreMaskSimpleSinh(benchmark::State &state) {
   SanityCheck(results);
 }
 BENCHMARK(BulkIgnoreMaskSimpleSinh);
+
+template <typename T>
+void InvMassBulkIgnoreMaskSinhCephes(const std::vector<bool> &eventMask,
+                                     std::size_t bulkSize,
+                                     std::vector<T> &results, const T *pt,
+                                     const T *eta, const T *phi, const T *mass,
+                                     const std::size_t *sizes) {
+
+  const auto nElements = std::accumulate(sizes, sizes + bulkSize, 0u);
+
+  std::vector<T> xs(nElements);
+  std::vector<T> ys(nElements);
+  std::vector<T> zs(nElements);
+  std::vector<T> es2(nElements);
+  std::vector<T> es(nElements);
+
+  // trigonometric functions are expensive and don't vectorize so we only call
+  // them when needed
+  std::size_t elementIdx = 0u;
+  for (std::size_t i = 0u; i < bulkSize; ++i) {
+    const auto size = sizes[i];
+    if (eventMask[i]) {
+      for (std::size_t j = 0u; j < size; ++j) {
+        const auto pt_ = pt[elementIdx + j];
+        const auto phi_ = phi[elementIdx + j];
+        xs[elementIdx + j] = pt_ * std::cos(phi_);
+        ys[elementIdx + j] = pt_ * std::sin(phi_);
+        zs[elementIdx + j] = pt_ * SinhCephes(eta[elementIdx + j]);
+      }
+    }
+    elementIdx += size;
+  }
+
+  // looks like the CPU is happier by calculating these for all elements, even
+  // if we'll discard many of the results...
+  for (std::size_t i = 0; i < nElements; ++i) {
+    es2[i] = pt[i] * pt[i] + zs[i] * zs[i] + mass[i] * mass[i];
+  }
+
+  for (std::size_t i = 0; i < nElements; ++i) {
+    es[i] = std::sqrt(es2[i]);
+  }
+
+  elementIdx = 0u;
+  for (std::size_t i = 0; i < bulkSize; ++i) {
+    T x_sum = 0.;
+    T y_sum = 0.;
+    T z_sum = 0.;
+    T e_sum = 0.;
+    const auto size = sizes[i];
+    if (eventMask[i]) {
+      for (std::size_t j = 0u; j < sizes[i]; ++j) {
+        const auto idx = elementIdx + j;
+        x_sum += xs[idx];
+        y_sum += ys[idx];
+        z_sum += zs[idx];
+        e_sum += es[idx];
+      }
+      results[i] = std::sqrt(e_sum * e_sum - x_sum * x_sum - y_sum * y_sum -
+                             z_sum * z_sum);
+    }
+    elementIdx += size;
+  }
+}
+
+static void BulkIgnoreMaskSinhCephes(benchmark::State &state) {
+  std::vector<float> results(input.bulkSize);
+  benchmark::DoNotOptimize(results);
+  for (auto _ : state) {
+    InvMassBulkIgnoreMaskSinhCephes(input.eventMask, input.bulkSize, results,
+                                    input.pts, input.etas, input.phis,
+                                    input.masses, input.sizes);
+    // to force writing to memory of results
+    benchmark::ClobberMemory();
+  }
+
+  SanityCheck(results);
+}
+BENCHMARK(BulkIgnoreMaskSinhCephes);
 
 template <typename T>
 void InvMassBulkIgnoreMaskPowerSeries(const std::vector<bool> &eventMask,


### PR DESCRIPTION
This uses a polynomial approximation for `|x| < 1` which is faster and should be more accurate than `exp(x)` at values close to zero, both of which are in a very important parameter regime for us.